### PR TITLE
Implement maximum nesting depth for ASN.1 decoder fix/unbounded-recur…

### DIFF
--- a/pyasn1/codec/ber/decoder.py
+++ b/pyasn1/codec/ber/decoder.py
@@ -21,7 +21,10 @@ __all__ = ["decode"]
 LOG = debug.registerLoggee(__name__, flags=debug.DEBUG_DECODER)
 
 noValue = base.noValue
-
+# Maximum recursion depth for nested SEQUENCE/SET structures.
+# Prevents unbounded recursion DoS (same fix as CVE-2026-30922 /
+# GHSA-jr27-m4p2-rc6r in mainline pyasn1, ported here).
+MAX_NESTING_DEPTH = 100
 
 class AbstractDecoder(object):
     protoComponent = None
@@ -1539,7 +1542,13 @@ class Decoder(object):
         substrateFun=None,
         **options
     ):
-
+        _nestingLevel = options.get('_nestingLevel', 0)
+        if _nestingLevel > MAX_NESTING_DEPTH:
+            raise error.PyAsn1Error(
+              'ASN.1 structure nesting depth exceeds limit (%d)' % MAX_NESTING_DEPTH
+            )
+           options['_nestingLevel'] = _nestingLevel + 1
+            
         if LOG:
             LOG(
                 "decoder called at scope %s with state %d, working with up to %d octets of substrate: %s"


### PR DESCRIPTION
…sion-dos

Added a maximum recursion depth limit to prevent unbounded recursion in ASN.1 decoding. Fix uncontrolled recursion DoS in BER decoder (port of CVE-2026-30922 fix)